### PR TITLE
Adding return value to survey testing function and adding "custom" for template type

### DIFF
--- a/expfactory/experiment.py
+++ b/expfactory/experiment.py
@@ -50,7 +50,7 @@ def dowarning(reason):
     print reason
 
 def get_valid_templates():
-    return ['jspsych','survey','phaser']
+    return ['jspsych','survey','phaser','custom']
 
 def get_acceptable_values(package_name):
     acceptable_values = dict()

--- a/expfactory/tests.py
+++ b/expfactory/tests.py
@@ -124,7 +124,7 @@ def circle_ci_survey(survey_tags,web_folder,survey_repo=None,delete=True,survey_
         print "Skipping surveys %s, no changes detected." %(",".join(survey_tags))
 
 
-def validate_surveys(survey_tags,survey_repo,survey_file="survey.tsv",delim="\t",raise_error=False):
+def validate_surveys(survey_tags,survey_repo,survey_file="survey.tsv",delim="\t",raise_error=True):
     '''validate_surveys validates an experiment factory survey folder
     :param survey_tags: a list of surveys to validate
     :param survey_repo: the survey repo with the survey folders to validate

--- a/expfactory/tests.py
+++ b/expfactory/tests.py
@@ -124,30 +124,37 @@ def circle_ci_survey(survey_tags,web_folder,survey_repo=None,delete=True,survey_
         print "Skipping surveys %s, no changes detected." %(",".join(survey_tags))
 
 
-def validate_surveys(survey_tags,survey_repo,survey_file="survey.tsv",delim="\t"):
+def validate_surveys(survey_tags,survey_repo,survey_file="survey.tsv",delim="\t",raise_error=False):
     '''validate_surveys validates an experiment factory survey folder
     :param survey_tags: a list of surveys to validate
     :param survey_repo: the survey repo with the survey folders to validate
     :param survey_file: the default file to validate
+    :param raise_error: throw the error (meaning don't return True or False instead)
     '''
     if isinstance(survey_tags,str):
         survey_tags = [survey_tags]
 
     for survey_tag in survey_tags:
-        survey_folder = "%s/%s" %(survey_repo,survey_tag)
-        print "Testing load of config.json for %s" %(survey_folder)
-        survey = load_experiment("%s" %survey_folder)
-        survey_questions = "%s/%s" %(survey_folder,survey_file)       
-        print "Testing valid columns in %s" %(survey[0]["exp_id"])
-        df = read_survey_file(survey_questions,delim=delim)
-        assert_equal(isinstance(df,pandas.DataFrame),True)
-        print "Testing survey generation of %s" %(survey[0]["exp_id"])
-        questions,required_count = parse_questions(survey_questions,
-                                                   exp_id=survey[0]["exp_id"],
-                                                   validate=True)
-        print "Testing validation generation of %s" %(survey[0]["exp_id"])
-        validation = parse_validation(required_count)
-      
+        try:
+            survey_folder = "%s/%s" %(survey_repo,survey_tag)
+            print "Testing load of config.json for %s" %(survey_folder)
+            survey = load_experiment("%s" %survey_folder)
+            survey_questions = "%s/%s" %(survey_folder,survey_file)       
+            print "Testing valid columns in %s" %(survey[0]["exp_id"])
+            df = read_survey_file(survey_questions,delim=delim)
+            assert_equal(isinstance(df,pandas.DataFrame),True)
+            print "Testing survey generation of %s" %(survey[0]["exp_id"])
+            questions,required_count = parse_questions(survey_questions,
+                                                       exp_id=survey[0]["exp_id"],
+                                                       validate=True)
+            print "Testing validation generation of %s" %(survey[0]["exp_id"])
+            validation = parse_validation(required_count)
+        except:
+            if raise_error == False:
+                return False
+            raise
+    return True
+
 
 def survey_robot_web(web_folder,survey_tags=None,port=None,pause_time=100):
     '''survey_robot_web


### PR DESCRIPTION
This PR will have survey testing return True,False (if variable "raise_error" is set to False, default is True) so the function can be used in other places to test if surveys are valid (outside of continuous integration). This will close #124. The second fix is to add "custom" as an acceptable experiment template variable (in the config.json) to allow for users to roll their own static experiments (for use with Expfactory version 2.0)
