### PR TITLE
Freeze/selenium version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ flask-restful
 gitpython
 scipy
 seaborn
-selenium
+selenium==2.53.6
 cognitiveatlas
 numexpr

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="expfactory",
 
     # Version number (initial):
-    version="2.5.45",
+    version="2.5.46",
 
     # Application author details:
     author="Vanessa Sochat",
@@ -29,7 +29,7 @@ setup(
     description="Python module for managing experiment factory experiments, for deployment to a psiturk battery or docker container.",
     keywords='psiturk behavior neuroscience experiment factory docker',
 
-    install_requires = ['requests','numpy','Flask','gitpython','flask-restful','selenium','cognitiveatlas','scipy','numexpr','seaborn'],
+    install_requires = ['requests','numpy','Flask','gitpython','flask-restful','selenium==2.53.6','cognitiveatlas','scipy','numexpr','seaborn'],
 
     entry_points = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="expfactory",
 
     # Version number (initial):
-    version="2.5.44",
+    version="2.5.45",
 
     # Application author details:
     author="Vanessa Sochat",


### PR DESCRIPTION
This will fix the continuous integration (experiment testing) errors that are triggered by the newer selenium not having the geko library in the path. If selenium has additional features that warrant the upgrade we can update the circle.yml, but for now this fix (freezing to the version that worked previously) seems reasonable.