### PR TITLE
FIX: css include order.

### DIFF
--- a/expfactory/templates/localbattery.html
+++ b/expfactory/templates/localbattery.html
@@ -2,7 +2,7 @@
   <head>
     <title>Experiment Factory Battery</title>
     <script src="static/lib/jquery-min.js" type="text/javascript"> </script> 
-
+    <link rel='stylesheet' href='static/css/jspsych.css' type="text/css">
     <link rel='stylesheet' href='static/css/default_style.css' type="text/css">  
     [SUB_EXPERIMENTSTATIC_SUB]    
     <script src="static/js/load_experiments.js" type="text/javascript"></script>


### PR DESCRIPTION
Include static/css/jspsych.css before static/css/default_style.css.
This gives a CSS cascade, in decreasing order of priority of

Local experiment
  Expfactory defaults
    JsPsych